### PR TITLE
feat: where/lower/upper, non-string map support

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,14 @@
+name: CI
+on: [push]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    name: Build & Test
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup go
+        uses: actions/setup-go@v1
+        with:
+          go-version: "1.18"
+      - run: go test -coverprofile=coverage.txt -covermode=atomic ./...
+      - uses: codecov/codecov-action@v1

--- a/README.md
+++ b/README.md
@@ -78,6 +78,9 @@ Internally all numbers are treated as `float64`, which means fewer conversions/c
 
 ### Accessing properties
 
+- Use `.` between property names
+- Use `[` and `]` for indexes, which can be negative
+
 ```py
 foo.bar[0].value
 ```
@@ -134,6 +137,7 @@ Non-boolean values are converted to booleans. The following result in `true`:
 - `.length` pseudo-property, e.g. `foo.length`
 - `+` (concatenation)
 - `in` e.g. `"f" in "foo"`
+- `contains` e.g. `"foo" contains "f"`
 - `startsWith` e.g. `"foo" startsWith "f"`
 - `endsWith` e.g. `"foo" endsWith "o"`
 
@@ -150,12 +154,44 @@ There is no distinction between strings, bytes, or runes. Everything is treated 
 - `.length` pseudo-property, e.g. `foo.length`
 - `+` (concatenation)
 - `in` (has item), e.g. `1 in foo`
+- `contains` e.g. `foo contains 1`
 
 Indexes are zero-based. Slice indexes are optional and are _inclusive_. `foo[1:2]` returns `[2, 3]` if the `foo` is `[1, 2, 3, 4]`. Indexes can be negative, e.g. `foo[-1]` selects the last item in the array.
+
+#### Array/slice filtering
+
+A `where` clause can be used to filter the items in an array. The left side of the clause is the array to be filtered, while the right side is an expression to run on each item of the array. If the right side expression evaluates to true then the item is added to the result. For example:
+
+```
+// Get a list of items where the item.id is bigger than 3
+items where id > 3
+
+// More complex example
+items where (id > 3 and labels contains "best")
+```
+
+This also makes it possible to implement one/any/all/none logic:
+
+```
+// One
+(items where id > 3).length == 1
+
+// Any
+items where id > 3
+(items where id > 3).length > 0
+
+// All
+(items where id > 3).length == items.length
+
+// None
+not (items where id > 3)
+(items where id > 3).length == 0
+```
 
 ### Map operators
 
 - `in` (has key), e.g. `"key" in foo`
+- `contains` e.g. `foo contains "key"`
 
 ## Performance
 

--- a/conversions.go
+++ b/conversions.go
@@ -39,7 +39,7 @@ func toNumber(ast *Node, v interface{}) (float64, Error) {
 	case float32:
 		return float64(n), nil
 	}
-	return 0, NewError(ast.Offset, ast.Length, "unable to convert to number")
+	return 0, NewError(ast.Offset, ast.Length, "unable to convert to number: %v", v)
 }
 
 func isString(v interface{}) bool {

--- a/expr.go
+++ b/expr.go
@@ -42,5 +42,8 @@ func Eval(expression string, input map[string]interface{}, options ...Interprete
 	if err != nil {
 		return nil, err
 	}
+	if ast == nil {
+		return nil, nil
+	}
 	return Run(ast, input, options...)
 }

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/danielgtaylor/mexpr
 
-go 1.17
+go 1.18
 
 require github.com/stretchr/testify v1.7.0
 

--- a/interpreter_test.go
+++ b/interpreter_test.go
@@ -70,6 +70,9 @@ func TestInterpreter(t *testing.T) {
 		{expr: "foo", input: `{"foo": 1.0}`, output: 1.0},
 		{expr: "foo.bar.baz", input: `{"foo": {"bar": {"baz": 1.0}}}`, output: 1.0},
 		{expr: `foo == "foo"`, input: `{"foo": "foo"}`, output: true},
+		{expr: `foo.in.not`, input: `{"foo": {"in": {"not": 1}}}`, output: 1.0},
+		{expr: `@`, input: `{"hello": "world"}`, output: map[string]interface{}{"hello": "world"}},
+		{expr: `hello.@`, input: `{"hello": "world"}`, output: "world"},
 		// Arrays
 		{expr: "foo[0]", input: `{"foo": [1, 2]}`, output: 1.0},
 		{expr: "foo[-1]", input: `{"foo": [1, 2]}`, output: 2.0},
@@ -89,6 +92,10 @@ func TestInterpreter(t *testing.T) {
 		{expr: `1 < 2 in "this is true"`, output: true},
 		{expr: `1 < 2 in "this is false"`, output: false},
 		{expr: `"bar" in foo`, input: `{"foo": {"bar": 1}}`, output: true},
+		// Contains
+		{expr: `"foobar" contains "foo"`, output: true},
+		{expr: `"foobar" contains "baz"`, output: false},
+		{expr: `labels contains "foo"`, input: `{"labels": ["foo", "bar"]}`, output: true},
 		// Starts / ends with
 		{expr: `"foo" startsWith "f"`, output: true},
 		{expr: `"foo" startsWith "o"`, output: false},
@@ -101,6 +108,14 @@ func TestInterpreter(t *testing.T) {
 		{expr: `"foo".length`, output: 3},
 		{expr: `str.length`, input: `{"str": "abcdef"}`, output: 6},
 		{expr: `arr.length`, input: `{"arr": [1, 2]}`, output: 2},
+		// Lower/Upper
+		{expr: `"foo".upper`, output: "FOO"},
+		{expr: `str.lower`, input: `{"str": "ABCD"}`, output: "abcd"},
+		// Where
+		{expr: `items where id > 3`, input: `{"items": [{"id": 1}, {"id": 3}, {"id": 5}, {"id": 7}]}`, output: []interface{}{map[string]interface{}{"id": 5.0}, map[string]interface{}{"id": 7.0}}},
+		{expr: `items where id > 3 where labels contains "foo"`, input: `{"items": [{"id": 1, "labels": ["foo"]}, {"id": 3}, {"id": 5, "labels": ["foo"]}, {"id": 7}]}`, output: []interface{}{map[string]interface{}{"id": 5.0, "labels": []interface{}{"foo"}}}},
+		{expr: `(items where id > 3).length == 2`, input: `{"items": [{"id": 1}, {"id": 3}, {"id": 5}, {"id": 7}]}`, output: true},
+		{expr: `not (items where id > 3)`, input: `{"items": [{"id": 1}, {"id": 3}, {"id": 5}, {"id": 7}]}`, output: false},
 		// Order of operations
 		{expr: "1 + 2 + 3", output: 6.0},
 		{expr: "1 + 2 * 3", output: 7.0},

--- a/parser.go
+++ b/parser.go
@@ -33,8 +33,10 @@ const (
 	NodeSlice
 	NodeSign
 	NodeIn
+	NodeContains
 	NodeStartsWith
 	NodeEndsWith
+	NodeWhere
 )
 
 // Node is a unit of the binary tree that makes up the abstract syntax tree.
@@ -91,10 +93,14 @@ func (n Node) String() string {
 		return ":"
 	case NodeIn:
 		return "in"
+	case NodeContains:
+		return "contains"
 	case NodeStartsWith:
 		return "startsWith"
 	case NodeEndsWith:
 		return "endsWith"
+	case NodeWhere:
+		return "where"
 	}
 
 	return ""
@@ -121,7 +127,8 @@ func (n Node) Dot(prefix string) string {
 var bindingPowers = map[TokenType]int{
 	TokenOr:            1,
 	TokenAnd:           2,
-	TokenStringCompare: 3,
+	TokenWhere:         3,
+	TokenStringCompare: 4,
 	TokenComparison:    5,
 	TokenSlice:         5,
 	TokenAddSub:        10,
@@ -376,12 +383,16 @@ func (p *parser) led(t *Token, n *Node) (*Node, Error) {
 		switch t.Value {
 		case "in":
 			nodeType = NodeIn
+		case "contains":
+			nodeType = NodeContains
 		case "startsWith":
 			nodeType = NodeStartsWith
 		case "endsWith":
 			nodeType = NodeEndsWith
 		}
 		return p.newNodeParseRight(n, t, nodeType, bindingPowers[t.Type])
+	case TokenWhere:
+		return p.newNodeParseRight(n, t, NodeWhere, bindingPowers[t.Type])
 	case TokenDot:
 		return p.newNodeParseRight(n, t, NodeFieldSelect, bindingPowers[t.Type])
 	case TokenLeftBracket:


### PR DESCRIPTION
This PR adds a number of new features without impacting performance:

- Switch to Go 1.18+
- `where` clause to filter array/slice items
- `lower` and `upper` pseudo-properties for strings
- Support for `map[interface{}]interface{}`
- Github actions for builds