### PR TITLE
feat: option to enable unquoted strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,23 @@ if err != nil {
 }
 ```
 
+### Options
+
+When running the interpreter a set of options can be passed in to change behavior. Available options:
+
+| Option            | Default | Description                                                                                        |
+| ----------------- | ------- | -------------------------------------------------------------------------------------------------- |
+| `StrictMode`      | `false` | Be more strict, for example return an error when an identifier is not found rather than `nil`      |
+| `UnquotedStrings` | `false` | Enable the use of unquoted strings, i.e. return a string instead of `nil` for undefined parameters |
+
+```go
+// Using the top-level eval
+mexpr.Eval(expression, inputObj, StrictMode)
+
+// Using an interpreter instance
+interpreter.Run(inputObj, StrictMode)
+```
+
 ## Syntax
 
 ### Literals


### PR DESCRIPTION
This PR adds a feature to enable the use of unquoted strings, which is off by default. When turned on, identifiers take precedence and if an identifier is not found it gets treated as a string. For example, `"foo" == foo` would result in `true` if `foo` is not defined and unquoted string support is enabled.

The options are documented in the README and several new tests related to unquoted strings are added.