### PR TITLE
fix: error if slice start > end

### DIFF
--- a/interpreter.go
+++ b/interpreter.go
@@ -159,6 +159,9 @@ func (i *interpreter) run(ast *Node, value any) (any, Error) {
 				if err := checkBounds(ast, left, int(end)); err != nil {
 					return nil, err
 				}
+				if int(start) > int(end) {
+					return nil, NewError(ast.Offset, ast.Length, "slice start cannot be greater than end")
+				}
 				return left[int(start) : int(end)+1], nil
 			}
 			left := toString(resultLeft)
@@ -170,6 +173,9 @@ func (i *interpreter) run(ast *Node, value any) (any, Error) {
 			}
 			if err := checkBounds(ast, left, int(start)); err != nil {
 				return nil, err
+			}
+			if int(start) > int(end) {
+				return nil, NewError(ast.Offset, ast.Length, "string slice start cannot be greater than end")
 			}
 			if err := checkBounds(ast, left, int(end)); err != nil {
 				return nil, err

--- a/interpreter_test.go
+++ b/interpreter_test.go
@@ -161,6 +161,8 @@ func TestInterpreter(t *testing.T) {
 		{expr: `1 / (foo * 1)`, input: `{"foo": 0}`, err: "cannot divide by zero"},
 		{expr: `1 before "2020-01-01"`, err: "unable to convert 1 to date or time"},
 		{expr: `"2020-01-01" after "invalid"`, err: "unable to convert invalid to date or time"},
+		{expr: `a[2:0]`, input: `{"a": [0, 1, 2]}`, err: "slice start cannot be greater than end"},
+		{expr: `a[2:0]`, input: `{"a": "hello"}`, err: "slice start cannot be greater than end"},
 	}
 
 	for _, tc := range cases {


### PR DESCRIPTION
Fixes a bug where array and string slices could cause a panic if the start > end.