### PR TITLE
fix: prevent panic on malformed slice

### DIFF
--- a/interpreter.go
+++ b/interpreter.go
@@ -137,7 +137,7 @@ func (i *interpreter) run(ast *Node, value any) (any, Error) {
 		if err != nil {
 			return nil, err
 		}
-		if isSlice(resultRight) {
+		if isSlice(resultRight) && len(resultRight.([]any)) == 2 {
 			start, err := toNumber(ast, resultRight.([]any)[0])
 			if err != nil {
 				return nil, err

--- a/interpreter_test.go
+++ b/interpreter_test.go
@@ -163,6 +163,8 @@ func TestInterpreter(t *testing.T) {
 		{expr: `"2020-01-01" after "invalid"`, err: "unable to convert invalid to date or time"},
 		{expr: `a[2:0]`, input: `{"a": [0, 1, 2]}`, err: "slice start cannot be greater than end"},
 		{expr: `a[2:0]`, input: `{"a": "hello"}`, err: "slice start cannot be greater than end"},
+		{expr: `a[0][-7]`, input: `{"a": [[]]}`, skipTC: true, err: "invalid index"},
+		{expr: `a[0]`, input: `{"a": []}`, skipTC: true, err: "invalid index"},
 	}
 
 	for _, tc := range cases {

--- a/typecheck.go
+++ b/typecheck.go
@@ -26,15 +26,15 @@ func (s *schema) String() string {
 }
 
 func (s *schema) isNumber() bool {
-	return s.typeName == typeNumber
+	return s != nil && s.typeName == typeNumber
 }
 
 func (s *schema) isString() bool {
-	return s.typeName == typeString
+	return s != nil && s.typeName == typeString
 }
 
 func (s *schema) isArray() bool {
-	return s.typeName == typeArray
+	return s != nil && s.typeName == typeArray
 }
 
 var (


### PR DESCRIPTION
Fixes a panic when slices are malformed that was found via fuzz testing CLI shorthand and makes the type checker more resilient against nested negative indexes when nested types are unavialable.