### PR TITLE
fix: pseudo-identifiers and unquoted strings

### DIFF
--- a/interpreter.go
+++ b/interpreter.go
@@ -76,6 +76,9 @@ func (i *interpreter) run(ast *Node, value any) (any, Error) {
 		return nil, nil
 	}
 
+	fromSelect := i.prevFieldSelect
+	i.prevFieldSelect = false
+
 	switch ast.Type {
 	case NodeIdentifier:
 		switch ast.Value.(string) {
@@ -108,12 +111,11 @@ func (i *interpreter) run(ast *Node, value any) (any, Error) {
 				return v, nil
 			}
 		}
-		if i.unquoted && !i.prevFieldSelect {
+		if i.unquoted && !fromSelect {
 			// Identifiers not found in the map are treated as strings, but only if
 			// the previous item was not a `.` like `obj.field`.
 			return ast.Value.(string), nil
 		}
-		i.prevFieldSelect = false
 		if !i.strict {
 			return nil, nil
 		}

--- a/interpreter_test.go
+++ b/interpreter_test.go
@@ -131,6 +131,7 @@ func TestInterpreter(t *testing.T) {
 		// Lower/Upper
 		{expr: `"foo".upper`, output: "FOO"},
 		{expr: `str.lower`, input: `{"str": "ABCD"}`, output: "abcd"},
+		{expr: `str.lower == abcd`, input: `{"str": "ABCD"}`, opts: []InterpreterOption{UnquotedStrings}, skipTC: true, output: true},
 		// Where
 		{expr: `items where id > 3`, input: `{"items": [{"id": 1}, {"id": 3}, {"id": 5}, {"id": 7}]}`, output: []interface{}{map[string]interface{}{"id": 5.0}, map[string]interface{}{"id": 7.0}}},
 		{expr: `items where id > 3 where labels contains "foo"`, input: `{"items": [{"id": 1, "labels": ["foo"]}, {"id": 3}, {"id": 5, "labels": ["foo"]}, {"id": 7}]}`, output: []interface{}{map[string]interface{}{"id": 5.0, "labels": []interface{}{"foo"}}}},
@@ -194,6 +195,7 @@ func TestInterpreter(t *testing.T) {
 					t.Fatal(err.Pretty(tc.expr))
 				}
 			}
+			t.Log("graph G {\n" + ast.Dot("") + "\n}")
 			result, err := Run(ast, input, tc.opts...)
 			if tc.err != "" {
 				if err == nil {


### PR DESCRIPTION
This change fixes a bug with pseudo-identifiers and unquoted strings where an expression like `str.lower == abcd` would return false when `str` is `ABCD`.  The value tracking whether the previous item was a field selector was not being reset properly on each iteration of the loop, which is resolved with this PR.