### PR TITLE
fix: empty array bug and unquoted typechecking

### DIFF
--- a/expr.go
+++ b/expr.go
@@ -4,7 +4,7 @@ package mexpr
 // Parse an expression and return the abstract syntax tree. If `types` is
 // passed, it should be a set of representative example values for the input
 // which will be used to type check the expression against.
-func Parse(expression string, types map[string]interface{}) (*Node, Error) {
+func Parse(expression string, types map[string]interface{}, options ...InterpreterOption) (*Node, Error) {
 	l := NewLexer(expression)
 	p := NewParser(l)
 	ast, err := p.Parse()
@@ -12,7 +12,7 @@ func Parse(expression string, types map[string]interface{}) (*Node, Error) {
 		return nil, err
 	}
 	if types != nil {
-		if err := TypeCheck(ast, types); err != nil {
+		if err := TypeCheck(ast, types, options...); err != nil {
 			return nil, err
 		}
 	}
@@ -21,8 +21,8 @@ func Parse(expression string, types map[string]interface{}) (*Node, Error) {
 
 // TypeCheck will take a parsed AST and type check against the given input
 // structure with representative example values.
-func TypeCheck(ast *Node, types map[string]interface{}) Error {
-	i := NewTypeChecker(ast)
+func TypeCheck(ast *Node, types map[string]interface{}, options ...InterpreterOption) Error {
+	i := NewTypeChecker(ast, options...)
 	return i.Run(types)
 }
 

--- a/interpreter.go
+++ b/interpreter.go
@@ -430,6 +430,9 @@ func (i *interpreter) run(ast *Node, value any) (any, Error) {
 			return nil, err
 		}
 		results := []any{}
+		if resultLeft == nil {
+			return nil, nil
+		}
 		for _, item := range resultLeft.([]any) {
 			resultRight, _ := i.run(ast.Right, item)
 			if i.strict && err != nil {

--- a/interpreter_test.go
+++ b/interpreter_test.go
@@ -81,6 +81,7 @@ func TestInterpreter(t *testing.T) {
 		{expr: `@.foo + 1`, opts: []InterpreterOption{UnquotedStrings, StrictMode}, err: "cannot get foo"},
 		{expr: `foo.bar == bar`, opts: []InterpreterOption{UnquotedStrings}, output: false},
 		{expr: `foo.bar == bar`, skipTC: true, opts: []InterpreterOption{UnquotedStrings}, input: `{"foo": {}}`, output: false},
+		{expr: `foo.bar == baz`, opts: []InterpreterOption{UnquotedStrings}, input: `{"foo": {"bar": "baz"}}`, output: true},
 		// Identifier / fields
 		{expr: "foo", input: `{"foo": 1.0}`, output: 1.0},
 		{expr: "foo.bar.baz", input: `{"foo": {"bar": {"baz": 1.0}}}`, output: 1.0},
@@ -137,6 +138,7 @@ func TestInterpreter(t *testing.T) {
 		{expr: `items where id > 3 where labels contains "foo"`, input: `{"items": [{"id": 1, "labels": ["foo"]}, {"id": 3}, {"id": 5, "labels": ["foo"]}, {"id": 7}]}`, output: []interface{}{map[string]interface{}{"id": 5.0, "labels": []interface{}{"foo"}}}},
 		{expr: `(items where id > 3).length == 2`, input: `{"items": [{"id": 1}, {"id": 3}, {"id": 5}, {"id": 7}]}`, output: true},
 		{expr: `not (items where id > 3)`, input: `{"items": [{"id": 1}, {"id": 3}, {"id": 5}, {"id": 7}]}`, output: false},
+		{expr: `items where id > 3`, input: `{}`, skipTC: true, output: nil},
 		// Order of operations
 		{expr: "1 + 2 + 3", output: 6.0},
 		{expr: "1 + 2 * 3", output: 7.0},
@@ -181,7 +183,7 @@ func TestInterpreter(t *testing.T) {
 				// Skip type check
 				types = nil
 			}
-			ast, err := Parse(tc.expr, types)
+			ast, err := Parse(tc.expr, types, tc.opts...)
 
 			if tc.err != "" {
 				if err != nil {


### PR DESCRIPTION
This PR fixes two bugs:

1. Panic when the left result of a `where` clause is `nil`
2. Type checking with unquoted strings enabled