### PR TITLE
fix: improved error msg, treat where ident as property

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Features:
     not (1- <= 5)
     ......^
   ```
+- Fuzz tested to prevent crashes
 
 ## Usage
 
@@ -216,6 +217,7 @@ not (items where id > 3)
 
 ### Map operators
 
+- Accessing values, e.g. `foo.bar.baz`
 - `in` (has key), e.g. `"key" in foo`
 - `contains` e.g. `foo contains "key"`
 

--- a/conversions.go
+++ b/conversions.go
@@ -127,6 +127,8 @@ func toBool(v interface{}) bool {
 		return len(n) > 0
 	case map[string]interface{}:
 		return len(n) > 0
+	case map[any]any:
+		return len(n) > 0
 	}
 	return false
 }

--- a/interpreter.go
+++ b/interpreter.go
@@ -121,6 +121,7 @@ func (i *interpreter) run(ast *Node, value any) (any, Error) {
 		}
 		return nil, NewError(ast.Offset, ast.Length, "cannot get %v from %v", ast.Value, value)
 	case NodeFieldSelect:
+		i.prevFieldSelect = true
 		leftValue, err := i.run(ast.Left, value)
 		if err != nil {
 			return nil, err
@@ -434,6 +435,10 @@ func (i *interpreter) run(ast *Node, value any) (any, Error) {
 			return nil, nil
 		}
 		for _, item := range resultLeft.([]any) {
+			// In an unquoted string scenario it makes no sense for the first/only
+			// token after a `where` clause to be treated as a string. Instead we
+			// treat a `where` the same as a field select `.` in this scenario.
+			i.prevFieldSelect = true
 			resultRight, _ := i.run(ast.Right, item)
 			if i.strict && err != nil {
 				return nil, err

--- a/interpreter_test.go
+++ b/interpreter_test.go
@@ -82,6 +82,9 @@ func TestInterpreter(t *testing.T) {
 		{expr: `foo.bar == bar`, opts: []InterpreterOption{UnquotedStrings}, output: false},
 		{expr: `foo.bar == bar`, skipTC: true, opts: []InterpreterOption{UnquotedStrings}, input: `{"foo": {}}`, output: false},
 		{expr: `foo.bar == baz`, opts: []InterpreterOption{UnquotedStrings}, input: `{"foo": {"bar": "baz"}}`, output: true},
+		{expr: `(items where foo).length == 1`, input: `{"items": [{"foo": 1}, {"bar": 2}, {"baz": 3}]}`, opts: []InterpreterOption{UnquotedStrings}, output: true},
+		{expr: `(items where @.foo).length == 1`, input: `{"items": [{"foo": 1}, {"bar": 2}, {"baz": 3}]}`, opts: []InterpreterOption{UnquotedStrings}, output: true},
+		{expr: `(items where foo in id).length == 1`, input: `{"items": [{"id": "foo123"}, {"id": "bar456"}, {"id": "baz789"}]}`, opts: []InterpreterOption{UnquotedStrings}, output: true},
 		// Identifier / fields
 		{expr: "foo", input: `{"foo": 1.0}`, output: 1.0},
 		{expr: "foo.bar.baz", input: `{"foo": {"bar": {"baz": 1.0}}}`, output: 1.0},

--- a/typecheck.go
+++ b/typecheck.go
@@ -179,6 +179,7 @@ func (i *typeChecker) run(ast *Node, value any) (*schema, Error) {
 		}
 		return nil, NewError(ast.Offset, ast.Length, "no property %v in %v", ast.Value, errValue)
 	case NodeFieldSelect:
+		i.prevFieldSelect = true
 		leftType, err := i.run(ast.Left, value)
 		if err != nil {
 			return nil, err
@@ -272,6 +273,10 @@ func (i *typeChecker) run(ast *Node, value any) (*schema, Error) {
 		if !leftType.isArray() {
 			return nil, NewError(ast.Offset, ast.Length, "where clause requires an array, but found %s", leftType)
 		}
+		// In an unquoted string scenario it makes no sense for the first/only
+		// token after a `where` clause to be treated as a string. Instead we
+		// treat a `where` the same as a field select `.` in this scenario.
+		i.prevFieldSelect = true
 		_, err = i.run(ast.Right, leftType.items)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
Provides better error messages for properties before a field select `.` token and when unquoted strings are enabled it treats a plain identifier in the where clause as a property rather than a potential string, e.g. `foo where bar` would return any `foo` which has a truthy `bar` field rather than non-intuitively returning all items because the string `"bar"` is truthy.