### PR TITLE
fix: ensure left side in where clause is a slice

### DIFF
--- a/interpreter.go
+++ b/interpreter.go
@@ -454,17 +454,19 @@ func (i *interpreter) run(ast *Node, value any) (any, Error) {
 			}
 			resultLeft = values
 		}
-		for _, item := range resultLeft.([]any) {
-			// In an unquoted string scenario it makes no sense for the first/only
-			// token after a `where` clause to be treated as a string. Instead we
-			// treat a `where` the same as a field select `.` in this scenario.
-			i.prevFieldSelect = true
-			resultRight, _ := i.run(ast.Right, item)
-			if i.strict && err != nil {
-				return nil, err
-			}
-			if toBool(resultRight) {
-				results = append(results, item)
+		if leftSlice, ok := resultLeft.([]any); ok {
+			for _, item := range leftSlice {
+				// In an unquoted string scenario it makes no sense for the first/only
+				// token after a `where` clause to be treated as a string. Instead we
+				// treat a `where` the same as a field select `.` in this scenario.
+				i.prevFieldSelect = true
+				resultRight, err := i.run(ast.Right, item)
+				if i.strict && err != nil {
+					return nil, err
+				}
+				if toBool(resultRight) {
+					results = append(results, item)
+				}
 			}
 		}
 		return results, nil

--- a/interpreter_test.go
+++ b/interpreter_test.go
@@ -145,6 +145,7 @@ func TestInterpreter(t *testing.T) {
 		{expr: `foo where method == "GET"`, input: `{"foo": {"op1": {"method": "GET", "path": "/op1"}, "op2": {"method": "PUT", "path": "/op2"}, "op3": {"method": "DELETE", "path": "/op3"}}}`, output: []any{map[string]any{"method": "GET", "path": "/op1"}}},
 		{expr: `foo where method == "GET"`, inputParsed: map[any]any{"foo": map[any]any{"op1": map[any]any{"method": "GET", "path": "/op1"}, "op2": map[any]any{"method": "PUT", "path": "/op2"}, "op3": map[any]any{"method": "DELETE", "path": "/op3"}}}, output: []any{map[any]any{"method": "GET", "path": "/op1"}}},
 		{expr: `items where id > 3`, input: `{"items": []}`, err: "where clause requires a non-empty array or object"},
+		{expr: `items where id > 3`, input: `{"items": 1}`, skipTC: true, output: []any{}},
 		// Order of operations
 		{expr: "1 + 2 + 3", output: 6.0},
 		{expr: "1 + 2 * 3", output: 7.0},


### PR DESCRIPTION
This fixes a panic when the left hand side value in a `where` clause evaluates to a non-slice value.